### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v3.2.0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.3.1
+      uses: actions/setup-python@v4.4.0
       with:
         python-version: 3.8
 

--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.3.1
+      uses: actions/setup-python@v4.4.0
       with:
         python-version: 3.8
 

--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -15,7 +15,7 @@ jobs:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 
     - name: Run GitHub Actions Version Updater
-      uses: saadmk11/github-actions-version-updater@pr-branch-config
+      uses: saadmk11/github-actions-version-updater@v0.7.2
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
         pull_request_branch: 'ghactions-autoupdate'

--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -2,7 +2,7 @@ name: Update GitHub Actions versions
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 * * * *'
 
 jobs:
   ghactions-autoupdate:
@@ -15,7 +15,7 @@ jobs:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 
     - name: Run GitHub Actions Version Updater
-      uses: saadmk11/github-actions-version-updater@v0.7.2
+      uses: saadmk11/github-actions-version-updater@pr-branch-config
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
         pull_request_branch: 'ghactions-autoupdate'

--- a/.github/workflows/pytest-and-coverage.yml
+++ b/.github/workflows/pytest-and-coverage.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v3.2.0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.3.1
+      uses: actions/setup-python@v4.4.0
       with:
         python-version: 3.8
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.7.2](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.7.2)** on 2022-12-25T12:22:31Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.4.0](https://github.com/actions/setup-python/releases/tag/v4.4.0)** on 2022-12-22T12:48:23Z
