### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.2.0
+      uses: actions/checkout@v3.3.0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.3.1
+      uses: actions/setup-python@v4.4.0
       with:
         python-version: 3.8
 

--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.2.0
+      uses: actions/checkout@v3.3.0
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.3.1
+      uses: actions/setup-python@v4.4.0
       with:
         python-version: 3.8
 

--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.2.0
+      uses: actions/checkout@v3.3.0
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/pytest-and-coverage.yml
+++ b/.github/workflows/pytest-and-coverage.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.2.0
+      uses: actions/checkout@v3.3.0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.3.1
+      uses: actions/setup-python@v4.4.0
       with:
         python-version: 3.8
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v4.4.0](https://github.com/actions/setup-python/releases/tag/v4.4.0)** on 2022-12-22T12:48:23Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.3.0](https://github.com/actions/checkout/releases/tag/v3.3.0)** on 2023-01-05T13:21:21Z
