### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
 
     - name: Set up Python
       uses: actions/setup-python@v4.5.0

--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
       with:
         fetch-depth: 0
 

--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/pytest-and-coverage.yml
+++ b/.github/workflows/pytest-and-coverage.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.0
+      uses: actions/checkout@v3.5.2
 
     - name: Set up Python
       uses: actions/setup-python@v4.5.0
@@ -28,7 +28,7 @@ jobs:
       run: pytest --cov=project_release --cov-report=term --cov-report=xml tests
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3.1.1
+      uses: codecov/codecov-action@v3.1.2
       with:
         files: coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.2](https://github.com/codecov/codecov-action/releases/tag/v3.1.2)** on 2023-04-11T20:10:46Z
