### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -28,13 +28,13 @@ jobs:
 
     - name: Publish package to TestPyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.8.5
+      uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish package to PyPI
       if: startsWith(github.ref, 'refs/tags') && !contains(github.ref, 'dev')
-      uses: pypa/gh-action-pypi-publish@v1.8.5
+      uses: pypa/gh-action-pypi-publish@v1.8.6
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.8.6](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.6)** on 2023-05-02T21:18:12Z
