### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/pytest-and-coverage.yml
+++ b/.github/workflows/pytest-and-coverage.yml
@@ -28,7 +28,7 @@ jobs:
       run: pytest --cov=project_release --cov-report=term --cov-report=xml tests
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3.1.3
+      uses: codecov/codecov-action@v3.1.4
       with:
         files: coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.4](https://github.com/codecov/codecov-action/releases/tag/v3.1.4)** on 2023-05-15T20:51:01Z
