### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v3.5.3
 
     - name: Set up Python
       uses: actions/setup-python@v4.6.1

--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v3.5.3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v3.5.3
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/pytest-and-coverage.yml
+++ b/.github/workflows/pytest-and-coverage.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v3.5.3
 
     - name: Set up Python
       uses: actions/setup-python@v4.6.1


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v3.5.3](https://github.com/actions/checkout/releases/tag/v3.5.3)** on 2023-06-09T15:05:56Z
