### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -28,13 +28,13 @@ jobs:
 
     - name: Publish package to TestPyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.8.8
+      uses: pypa/gh-action-pypi-publish@v1.8.10
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish package to PyPI
       if: startsWith(github.ref, 'refs/tags') && !contains(github.ref, 'dev')
-      uses: pypa/gh-action-pypi-publish@v1.8.8
+      uses: pypa/gh-action-pypi-publish@v1.8.10
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -15,7 +15,7 @@ jobs:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 
     - name: Run GitHub Actions Version Updater
-      uses: saadmk11/github-actions-version-updater@v0.7.4
+      uses: saadmk11/github-actions-version-updater@v0.8.1
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
         pull_request_branch: 'ghactions-autoupdate'


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.0](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.0)** on 2023-08-06T06:09:30Z
