### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v4.1.1
 
     - name: Set up Python
-      uses: actions/setup-python@v4.7.1
+      uses: actions/setup-python@v5.0.0
       with:
         python-version: 3.8
 
@@ -28,13 +28,13 @@ jobs:
 
     - name: Publish package to TestPyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.8.10
+      uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish package to PyPI
       if: startsWith(github.ref, 'refs/tags') && !contains(github.ref, 'dev')
-      uses: pypa/gh-action-pypi-publish@v1.8.10
+      uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v4.7.1
+      uses: actions/setup-python@v5.0.0
       with:
         python-version: 3.8
 

--- a/.github/workflows/pytest-and-coverage.yml
+++ b/.github/workflows/pytest-and-coverage.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v4.1.1
 
     - name: Set up Python
-      uses: actions/setup-python@v4.7.1
+      uses: actions/setup-python@v5.0.0
       with:
         python-version: 3.8
 
@@ -28,7 +28,8 @@ jobs:
       run: pytest --cov=project_release --cov-report=term --cov-report=xml tests
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3.1.4
+      uses: codecov/codecov-action@v4.0.2
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml
         fail_ci_if_error: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.8.11](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.11)** on 2023-11-29T02:41:33Z
