### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.2.2
 
     - name: Set up Python
-      uses: actions/setup-python@v5.0.0
+      uses: actions/setup-python@v5.6.0
       with:
         python-version: 3.8
 
@@ -28,13 +28,13 @@ jobs:
 
     - name: Publish package to TestPyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@v1.8.14
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
 
     - name: Publish package to PyPI
       if: startsWith(github.ref, 'refs/tags') && !contains(github.ref, 'dev')
-      uses: pypa/gh-action-pypi-publish@v1.8.14
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/enforce-conventional-commits.yml
+++ b/.github/workflows/enforce-conventional-commits.yml
@@ -12,12 +12,12 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.2.2
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v5.0.0
+      uses: actions/setup-python@v5.6.0
       with:
         python-version: 3.8
 

--- a/.github/workflows/ghactions-autoupdate.yml
+++ b/.github/workflows/ghactions-autoupdate.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.2.2
       with:
         token: ${{ secrets.WORKFLOW_TOKEN }}
 

--- a/.github/workflows/pytest-and-coverage.yml
+++ b/.github/workflows/pytest-and-coverage.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
 
     - name: Check out the repo
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@v4.2.2
 
     - name: Set up Python
-      uses: actions/setup-python@v5.0.0
+      uses: actions/setup-python@v5.6.0
       with:
         python-version: 3.8
 
@@ -28,7 +28,7 @@ jobs:
       run: pytest --cov=project_release --cov-report=term --cov-report=xml tests
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4.1.0
+      uses: codecov/codecov-action@v5.4.3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.xml


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v4.1.1](https://github.com/codecov/codecov-action/releases/tag/v4.1.1)** on 2024-03-26T16:04:10Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.1.0](https://github.com/actions/setup-python/releases/tag/v5.1.0)** on 2024-03-26T14:09:17Z
